### PR TITLE
fix: adds esm import path to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "bugs": {
     "url": "https://github.com/leighton-digital/lambda-toolkit/issues"
   },
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Adds esm import path for the package exports, to allow importing the module with esbuild.
- Updated main definition in `package.json` to use relative path.
- Adds top level types definition in `package.json`.

Without this we receive `The path "." is not currently exported by package "@leighton-digital/lambda-toolkit"` when importing with ESM.

## Checklist
- [X] No secrets or credentials added
- [X] Updated SECURITY.md if needed
- [X] Updated documentation if needed

## Security Considerations
<!-- Threats mitigated, permissions changes, dependency risk, rollout plan -->
I've added the import definition to the exports block, rather than removing the exports block and falling back to the defaults (which match our definitions) to keep the surface area private.
