### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -1,4 +1,6 @@
 name: Quality Checks
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/6](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/6)

To fix the problem, you should add an explicit `permissions` block to the root of the workflow file, right below the workflow name and before the `on:` trigger. This block should assign the minimum required privileges to the GITHUB_TOKEN for the workflow execution—typically `contents: read` is sufficient for read-only operations like linting, type checking, and testing. If more permissions are required for other workflow actions, you can further refine the permissions, but for these jobs, they generally only need to read source code, not write. You should edit `.github/workflows/_quality-checks.yaml` and insert the following at line 2:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
