### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -1,4 +1,6 @@
 name: Quality Checks
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/5](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/5)

To fix this problem, we should explicitly declare the minimal required `permissions` for the workflow at the top level (root), or for each job if their needs differ. Because the jobs shown (`linting`, `typeCheck`, `unitTest`) only use read access to repository contents and do not modify issues, pull requests, etc., the most minimal starting point is `contents: read`. This should be placed at the root of `.github/workflows/_quality-checks.yaml`, so all jobs inherit it by default. To implement this, add the following block under the workflow name (`name: Quality Checks`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
