### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -1,4 +1,6 @@
 name: Quality Checks
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/4](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/4)

The best way to fix the problem is to add a top-level `permissions` block to the workflow YAML file. This block should specify the minimal set of permissions required for the jobs in this workflow to operate correctly. As these jobs (linting, type checking, and unit testing) typically only require reading repository contents, the most restrictive and appropriate permission set is likely `contents: read`. This can be added under the workflow `name` and `on` sections and will apply by default to all jobs unless individually overridden. The change is to insert a block:

```yaml
permissions:
  contents: read
```

directly after the `name` field and before the `on` field, in `.github/workflows/_quality-checks.yaml`. No code outside the shown snippet needs to be edited or imports added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
