### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_node_job.yaml
+++ b/.github/workflows/_node_job.yaml
@@ -15,6 +15,8 @@ on:
 jobs:
   node-job:
     name: ${{inputs.name}}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: ${{inputs.timeout-minutes}}
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/1](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/1)

The best way to resolve the issue is to add a `permissions` block to the workflow (either at root or within the `node-job` job) specifying only the minimum level of access required for the workflow to run successfully. In this case, the `actions/checkout` action requires `contents: read` for most operations, and there is no evidence of steps requiring write access. Thus, insert `permissions: contents: read` under either the root of the workflow YAML (before `jobs:` for global effect) or under the specific job (`node-job:`) for job-local effect. Since only one job exists, adding it at the job level is clear and sufficient.

No changes to imports, method definitions, or other parts of the code are required for YAML workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
