### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/3](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/3)

To fix the problem, we should set an explicit `permissions:` block for the workflow or its jobs, limiting GITHUB_TOKEN to the minimum required permissions. Since the jobs only check out code and build artifacts, `contents: read` is sufficient. The best way is to add `permissions: contents: read` at the root level (i.e., right after `name:` and before `on:`), ensuring no job inadvertently runs with full write permissions. No other privilege types are needed. You only need to modify the workflow YAML file: `.github/workflows/_build.yaml`, inserting the block after line 1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
