### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/2](https://github.com/leighton-digital/lambda-toolkit/security/code-scanning/2)

To resolve the issue, add a `permissions` block specifying the minimum necessary privileges for the workflow. Given the workflow's usage patterns—checking out code, setup, building, and caching—the only required permission is typically `contents: read`. The optimal fix is to add a `permissions` block with `contents: read` at the root of the workflow YAML (before the `jobs` block). This will apply to all jobs unless overridden by job-level permissions. No new imports or other changes are necessary. Edit `.github/workflows/_build.yaml` by inserting:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
